### PR TITLE
Add support for TypeScript and TypeScript React

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This will enable the `.` text object (this is the mapping I use but `<cr>` is qu
 
 ## textsubjects-smart
 
-**Supported Languages**: `Lua`, `Rust`, `Go`, `Ruby`, `Python`.
+**Supported Languages**: `Lua`, `Rust`, `Go`, `Ruby`, `Python`, `JavaScript / JSX`, `TypeScript / TSX`.
 
 **Patterns**: comments, consecutive line comments, function calls, function definitions, class definitions, loops, if statements, return values, arguments.
 

--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,2 @@
+nvim-treesitter-textsubjects	nvim-treesitter-textsubjects.txt	/*nvim-treesitter-textsubjects*
+nvim-treesitter-textsubjects-query-files	nvim-treesitter-textsubjects.txt	/*nvim-treesitter-textsubjects-query-files*

--- a/queries/javascript/textsubjects-smart.scm
+++ b/queries/javascript/textsubjects-smart.scm
@@ -1,0 +1,46 @@
+((comment) @_start @_end
+     (#make-range! "range" @_start @_end))
+
+; TODO This query doesn't work for comment groups at the start and end of a
+; file
+; See https://github.com/tree-sitter/tree-sitter/issues/1138
+(((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
+    (#not-has-type? @tail "comment")
+    (#not-has-type? @head "comment")
+    (#make-range! "range" @_start @_end))
+
+(([
+    (function_declaration)
+    (expression_statement)
+    (lexical_declaration)
+    (class_declaration)
+    (method_definition)
+    (for_statement)
+    (for_in_statement)
+    (if_statement)
+    (switch_statement)
+    ; jsx
+    (jsx_element)
+    (jsx_fragment)
+    (jsx_self_closing_element)
+    (jsx_attribute)
+] @_start @_end)
+(#make-range! "range" @_start @_end))
+
+((formal_parameters (_) @_start @_end . ","? @_end)
+    (#make-range! "range" @_start @_end))
+
+((arguments (_) @_start @_end . ","? @_end)
+    (#make-range! "range" @_start @_end))
+
+((object (_) @_start @_end . ","? @_end)
+    (#make-range! "range" @_start @_end))
+
+((array (_) @_start @_end . ","? @_end)
+    (#make-range! "range" @_start @_end))
+
+((class_body (_) @_start @_end . ";"? @_end)
+    (#make-range! "range" @_start @_end))
+
+((return_statement (_) @_start @_end)
+    (#make-range! "range" @_start @_end))

--- a/queries/tsx/textsubjects-smart.scm
+++ b/queries/tsx/textsubjects-smart.scm
@@ -1,0 +1,53 @@
+((comment) @_start @_end
+     (#make-range! "range" @_start @_end))
+
+; TODO This query doesn't work for comment groups at the start and end of a
+; file
+; See https://github.com/tree-sitter/tree-sitter/issues/1138
+(((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
+    (#not-has-type? @tail "comment")
+    (#not-has-type? @head "comment")
+    (#make-range! "range" @_start @_end))
+
+(([
+    (function_declaration)
+    (expression_statement)
+    (lexical_declaration)
+    (class_declaration)
+    (method_definition)
+    (for_statement)
+    (for_in_statement)
+    (if_statement)
+    (switch_statement)
+    ; typescript
+    (type_alias_declaration)
+    (interface_declaration)
+    ; jsx
+    (jsx_element)
+    (jsx_fragment)
+    (jsx_self_closing_element)
+    (jsx_attribute)
+] @_start @_end)
+(#make-range! "range" @_start @_end))
+
+((formal_parameters (_) @_start @_end . ","? @_end)
+    (#make-range! "range" @_start @_end))
+
+((arguments (_) @_start @_end . ","? @_end)
+    (#make-range! "range" @_start @_end))
+
+((object (_) @_start @_end . ","? @_end)
+    (#make-range! "range" @_start @_end))
+
+((array (_) @_start @_end . ","? @_end)
+    (#make-range! "range" @_start @_end))
+
+((class_body (_) @_start @_end . ";"? @_end)
+    (#make-range! "range" @_start @_end))
+
+((return_statement (_) @_start @_end)
+    (#make-range! "range" @_start @_end))
+
+; typescript
+((object_type (_) @_start @_end . ";"? @_end)
+    (#make-range! "range" @_start @_end))

--- a/queries/typescript/textsubjects-smart.scm
+++ b/queries/typescript/textsubjects-smart.scm
@@ -1,0 +1,47 @@
+((comment) @_start @_end
+     (#make-range! "range" @_start @_end))
+
+; TODO This query doesn't work for comment groups at the start and end of a
+; file
+; See https://github.com/tree-sitter/tree-sitter/issues/1138
+(((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
+    (#not-has-type? @tail "comment")
+    (#not-has-type? @head "comment")
+    (#make-range! "range" @_start @_end))
+
+(([
+    (function_declaration)
+    (expression_statement)
+    (lexical_declaration)
+    (class_declaration)
+    (method_definition)
+    (for_statement)
+    (for_in_statement)
+    (if_statement)
+    (switch_statement)
+    ; typescript
+    (type_alias_declaration)
+    (interface_declaration)
+] @_start @_end)
+(#make-range! "range" @_start @_end))
+
+((formal_parameters (_) @_start @_end . ","? @_end)
+    (#make-range! "range" @_start @_end))
+
+((arguments (_) @_start @_end . ","? @_end)
+    (#make-range! "range" @_start @_end))
+
+((object (_) @_start @_end . ","? @_end)
+    (#make-range! "range" @_start @_end))
+
+((array (_) @_start @_end . ","? @_end)
+    (#make-range! "range" @_start @_end))
+
+((class_body (_) @_start @_end . ";"? @_end)
+    (#make-range! "range" @_start @_end))
+
+((return_statement (_) @_start @_end)
+    (#make-range! "range" @_start @_end))
+
+((object_type (_) @_start @_end . ";"? @_end)
+    (#make-range! "range" @_start @_end))


### PR DESCRIPTION
First pass at adding support for `typescript` and `tsx`. I'm impressed at how simple and useful the core idea of the plugin is, and it works particularly well for `tsx`, which can be troublesome with traditional Vim text objects. 

A couple of questions:

1. Do we want to add support for JavaScript and JavaScript React? It would be simple to take out the type-specific stuff from the queries, but I imagine it would add some maintenance overhead.
2. In a lot of cases, I think it would be useful to select a range without its enclosing brackets. For example:

```typescript
const checkIfEqual = (first: number, second: number) => {
  if (first === second) {
    console.log("equal");
  }
};
```

If my cursor is on the `c` in `console.log` and I type `v.`, it'll first select the line (which matches the `expression_statement` query). Typing `.` again will select the body of the if statement, including the enclosing brackets (which matches the `statement_block` query). If I type `c` to change the block, I'll have to re-add the brackets. Is there a way to structure the query so that it captures `statement_block`, minus the brackets? 