### PR TITLE
Adapt Lua queries to upstream switch

### DIFF
--- a/queries/lua/textsubjects-big.scm
+++ b/queries/lua/textsubjects-big.scm
@@ -1,6 +1,5 @@
 (([
+    (function_declaration)
     (function_definition)
-    (local_function)
-    (function)
 ] @_start @_end)
 (#make-range! "range" @_start @_end))

--- a/queries/lua/textsubjects-container-outer.scm
+++ b/queries/lua/textsubjects-container-outer.scm
@@ -1,6 +1,5 @@
 (([
+    (function_declaration)
     (function_definition)
-    (local_function)
-    (function)
 ] @_start @_end)
 (#make-range! "range" @_start @_end))

--- a/queries/lua/textsubjects-smart.scm
+++ b/queries/lua/textsubjects-smart.scm
@@ -1,9 +1,8 @@
 ((comment) @_start @_end
      (#make-range! "range" @_start @_end))
 
-; TODO This query doesn't work for comment groups at the start and end of a
-; file
-; See https://github.com/tree-sitter/tree-sitter/issues/1138
+; TODO: This query doesn't work for comment groups at the start and end of a file
+;       See: https://github.com/tree-sitter/tree-sitter/issues/1138
 (((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
     (#not-has-type? @tail "comment")
     (#not-has-type? @head "comment")
@@ -11,15 +10,13 @@
 
 (([
     (function_call)
+    (function_declaration)
     (function_definition)
-    (local_function)
-    (function)
     (do_statement)
-    (repeat_statement)
     (while_statement)
-    (for_in_statement)
-    (for_statement)
+    (repeat_statement)
     (if_statement)
+    (for_statement)
 ] @_start @_end)
 (#make-range! "range" @_start @_end))
 
@@ -29,7 +26,7 @@
 ((arguments (_) @_start @_end . ","? @_end)
     (#make-range! "range" @_start @_end))
 
-((table (_) @_start @_end . ["," ";"]? @_end)
+((table_constructor (_) @_start @_end . ["," ";"]? @_end)
     (#make-range! "range" @_start @_end))
 
 ((return_statement (_) @_start @_end)


### PR DESCRIPTION
nvim-treesitter switched to a different Lua parser in nvim-treesitter/nvim-treesitter#2272, which requires adaptation of queries