### PR TITLE
Add support for C and C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Whether the selection is by character or by line will also depend on your locati
 
 |                      | `container-inner`    | `container-outer`    | `smart`        |
 | -------------------- | -------------------- | -------------------- | -------------- |
+| `c`                  | :green_square:       | :green_square:       | :green_square: |
+| `cpp`                | :green_square:       | :green_square:       | :green_square: |
 | `elixir`             | :white_large_square: | :green_square:       | :green_square: |
 | `foam`               | :white_large_square: | :green_square:       | :green_square: |
 | `go`                 | :green_square:       | :green_square:       | :green_square: |

--- a/doc/nvim-treesitter-textsubjects.txt
+++ b/doc/nvim-treesitter-textsubjects.txt
@@ -59,9 +59,9 @@ Builtin Text Subject Queries | Description                                      
 -----------------------------+------------------------------------------------
 
 Supported Languages:
-    - `textsubjects-smart`: `Lua`, `Rust`, `Go`, `Ruby`, `Python`, `Elixir`, `Julia`
-    - `textsubjects-container-outer`: `Lua`, `Rust`, `Go`, `Ruby`, `Python`, `Elixir`, `Julia`
-    - `textsubjects-container-inner`: `Lua`, `Rust`, `Go`, `Ruby`, `Python`
+    - `textsubjects-smart`: `C`, `C++`, `Lua`, `Rust`, `Go`, `Ruby`, `Python`, `Elixir`, `Julia`
+    - `textsubjects-container-outer`: `C`, `C++`, `Lua`, `Rust`, `Go`, `Ruby`, `Python`, `Elixir`, `Julia`
+    - `textsubjects-container-inner`: `C`, `C++`, `Lua`, `Rust`, `Go`, `Ruby`, `Python`
 
 
 vim:tw=78:ts=8:expandtab:noet:ft=help:norl:

--- a/queries/c/textsubjects-container-inner.scm
+++ b/queries/c/textsubjects-container-inner.scm
@@ -1,0 +1,22 @@
+; {} blocks
+([
+    (compound_statement . "{" . (_) @_start @_end (_)? @_end . "}" .)
+    (declaration_list . "{" . (_) @_start @_end (_)? @_end . "}" . )
+    (enumerator_list . "{" . (_) @_start @_end (_)? @_end . "}" . )
+    (field_declaration_list . "{" . (_) @_start @_end (_)? @_end . "}" . )
+    (initializer_list . "{" . (_) @_start @_end (_)? @_end . "}" . )
+] (#make-range! "range" @_start @_end))
+
+; () blocks
+([
+    (argument_list . "(" . (_) @_start @_end (_)? @_end . ")" . )
+    (parameter_list . "(" . (_) @_start @_end (_)? @_end . ")" . )
+    (sizeof_expression (parenthesized_expression (_) @_start @_end)) ; sizeof(expr)
+    (sizeof_expression . "(" . (_) @_start @_end . ")" . ) ; sizeof(type)
+    (do_statement condition: (parenthesized_expression (_) @_start @_end))
+    (if_statement condition: (parenthesized_expression (_) @_start @_end))
+    (switch_statement condition: (parenthesized_expression (_) @_start @_end))
+    (while_statement condition: (parenthesized_expression (_) @_start @_end))
+    (for_statement . "(" . (_) @_start @_end (_)? @_end . ")" . (_))
+] (#make-range! "range" @_start @_end))
+

--- a/queries/c/textsubjects-container-outer.scm
+++ b/queries/c/textsubjects-container-outer.scm
@@ -1,0 +1,19 @@
+(([
+    ; definition blocks
+    (declaration)
+    (function_definition)
+    (field_declaration)
+    (preproc_call)
+    (preproc_def)
+    (preproc_function_def)
+    (preproc_if)
+    (preproc_ifdef)
+    (preproc_include)
+
+    ; things that look like class definitions
+    (enum_specifier)
+    (struct_specifier)
+    (union_specifier)
+  ] @_start @_end)
+    (#make-range! "range" @_start @_end))
+

--- a/queries/c/textsubjects-smart.scm
+++ b/queries/c/textsubjects-smart.scm
@@ -1,0 +1,81 @@
+((comment) @_start @_end
+    (#make-range! "range" @_start @_end))
+
+; TODO This query doesn't work for comment groups at the start and end of a
+; file
+; See https://github.com/tree-sitter/tree-sitter/issues/1138
+(((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
+    (#not-has-type? @tail "comment")
+    (#not-has-type? @head "comment")
+    (#make-range! "range" @_start @_end))
+
+(([
+    ; definition blocks
+    (declaration)
+    (function_definition)
+    (field_declaration)
+    (preproc_call)
+    (preproc_def)
+    (preproc_function_def)
+    (preproc_if)
+    (preproc_ifdef)
+    (preproc_include)
+
+    ; things that look like class definitions
+    (enum_specifier)
+    (struct_specifier)
+    (union_specifier)
+
+    ; control flow, statements
+    (do_statement)
+    (expression_statement)
+    (for_statement)
+    (if_statement)
+    (switch_statement)
+    (while_statement)
+
+    ; expressions that look like function calls
+    (call_expression)
+    (cast_expression)
+    (sizeof_expression)
+
+    ; {} blocks
+    (compound_statement)
+    (declaration_list)
+    (field_declaration_list)
+
+    ; {} blocks with delimited lists
+    (enumerator_list)
+    (initializer_list)
+
+    ; delimited lists
+    (argument_list)
+    (parameter_list)
+] @_start @_end)
+    (#make-range! "range" @_start @_end))
+
+; elements of delimited lists
+([
+    (argument_list (_) @_start @_end . ","? @_end)
+    (enumerator_list (_) @_start @_end . ","? @_end)
+    (initializer_list (_) @_start @_end . ","? @_end)
+    (parameter_list (_) @_start @_end . ","? @_end)
+] (#make-range! "range" @_start @_end))
+
+; contents of keyword statements
+((return_statement (_) @_start @_end)
+    (#make-range! "range" @_start @_end))
+
+; the parenthesized parts of control flow statements
+([
+    (do_statement condition: (_) @_start @_end)
+    (if_statement condition: (_) @_start @_end)
+    (switch_statement condition: (_) @_start @_end)
+    (while_statement condition: (_) @_start @_end)
+
+    ; for contents, initializer, condition and update
+    (for_statement . "(" @_start (_)* ")" @_end . (_))
+    (for_statement . "(" . (_) @_start @_end (_)? @_end . ";" . (_))
+    (for_statement condition: (_) @_start @_end . ";"? @_end)
+    (for_statement update: (_) @_start @_end)
+] (#make-range! "range" @_start @_end))

--- a/queries/cpp/textsubjects-container-inner.scm
+++ b/queries/cpp/textsubjects-container-inner.scm
@@ -1,0 +1,28 @@
+; {} blocks
+([
+    (compound_statement . "{" . (_) @_start @_end (_)? @_end . "}" .)
+    (declaration_list . "{" . (_) @_start @_end (_)? @_end . "}" . )
+    (enumerator_list . "{" . (_) @_start @_end (_)? @_end . "}" . )
+    (field_declaration_list . "{" . (_) @_start @_end (_)? @_end . "}" . )
+    (initializer_list . "{" . (_) @_start @_end (_)? @_end . "}" . )
+] (#make-range! "range" @_start @_end))
+
+; () blocks
+([
+    (argument_list . "(" . (_) @_start @_end (_)? @_end ")" . )
+    (parameter_list . "(" . (_) @_start @_end (_)? @_end ")" . )
+    (decltype (_) @_start @_end)
+    (sizeof_expression (parenthesized_expression (_) @_start @_end)) ; sizeof(expr)
+    (sizeof_expression . "(" . (_) @_start @_end . ")" . ) ; sizeof(type)
+    (static_assert_declaration . "(" . (_) @_start @_end (_)? @_end . ")" . )
+    (condition_clause (_) @_start @_end)
+    (do_statement condition: (parenthesized_expression (_) @_start @_end))
+    (for_statement . "(" . (_) @_start @_end (_)* @_end . ")" . (_))
+    (for_range_loop . "(" . (_) @_start @_end (_)* @_end . ")" . (_))
+] (#make-range! "range" @_start @_end))
+
+; <> blocks
+([
+    (template_argument_list . "<" . (_) @_start @_end (_)? @_end . ">" . )
+    (template_parameter_list . "<" . (_) @_start @_end (_)? @_end . ">" . )
+] (#make-range! "range" @_start @_end))

--- a/queries/cpp/textsubjects-container-outer.scm
+++ b/queries/cpp/textsubjects-container-outer.scm
@@ -1,0 +1,28 @@
+(([
+    ; definition blocks
+    (alias_declaration)
+    (concept_definition)
+    (declaration)
+    (field_declaration)
+    (function_definition)
+    (lambda_expression)
+    (linkage_specification)
+    (namespace_alias_definition)
+    (namespace_definition)
+    (preproc_call)
+    (preproc_def)
+    (preproc_function_def)
+    (preproc_if)
+    (preproc_ifdef)
+    (preproc_include)
+    (template_declaration)
+    (template_instantiation)
+    (using_declaration)
+
+    ; things that look like class definitions
+    (class_specifier)
+    (enum_specifier)
+    (struct_specifier)
+    (union_specifier)
+  ] @_start @_end)
+    (#make-range! "range" @_start @_end))

--- a/queries/cpp/textsubjects-smart.scm
+++ b/queries/cpp/textsubjects-smart.scm
@@ -1,0 +1,116 @@
+((comment) @_start @_end
+    (#make-range! "range" @_start @_end))
+
+; TODO This query doesn't work for comment groups at the start and end of a
+; file
+; See https://github.com/tree-sitter/tree-sitter/issues/1138
+(((_) @head . (comment) @_start . (comment)+ @_end (_) @tail)
+    (#not-has-type? @tail "comment")
+    (#not-has-type? @head "comment")
+    (#make-range! "range" @_start @_end))
+
+(([
+    ; definition blocks
+    (alias_declaration)
+    (concept_definition)
+    (declaration)
+    (field_declaration)
+    (function_definition)
+    (lambda_expression)
+    (linkage_specification)
+    (namespace_alias_definition)
+    (namespace_definition)
+    (preproc_call)
+    (preproc_def)
+    (preproc_function_def)
+    (preproc_if)
+    (preproc_ifdef)
+    (preproc_include)
+    (template_declaration)
+    (template_instantiation)
+    (using_declaration)
+
+    ; things that look like class definitions
+    (class_specifier)
+    (enum_specifier)
+    (struct_specifier)
+    (union_specifier)
+
+    ; control flow statements and statements
+    (catch_clause)
+    (do_statement)
+    (expression_statement)
+    (for_range_loop)
+    (for_statement)
+    (if_statement)
+    (switch_statement)
+    (try_statement)
+    (while_statement)
+
+    ; expressions that look like function calls
+    (call_expression)
+    (cast_expression)
+    (decltype)
+    (sizeof_expression)
+    (static_assert_declaration)
+
+    ; {} blocks
+    (compound_statement)
+    (declaration_list)
+    (field_declaration_list)
+
+    ; {} blocks with delimited lists
+    (enumerator_list)
+    (initializer_list)
+
+    ; delimited lists
+    (argument_list)
+    (field_initializer_list)
+    (parameter_list)
+    (template_argument_list)
+    (template_parameter_list)
+] @_start @_end)
+    (#make-range! "range" @_start @_end))
+
+; elements of delimited lists
+([
+    (argument_list (_) @_start @_end . ","? @_end)
+    (enumerator_list (_) @_start @_end . ","? @_end)
+    (field_initializer_list (_) @_start @_end . ","? @_end)
+    (initializer_list (_) @_start @_end . ","? @_end)
+    (parameter_list (_) @_start @_end . ","? @_end)
+    (template_argument_list (_) @_start @_end . ","? @_end)
+    (template_parameter_list (_) @_start @_end . ","? @_end)
+] (#make-range! "range" @_start @_end))
+
+; contents of keyword statements
+([
+    (return_statement (_) @_start @_end)
+    (throw_statement (_) @_start @_end)
+    (co_return_statement (_) @_start @_end)
+    (co_yield_statement (_) @_start @_end)
+    (co_await_expression (_) @_start @_end)
+    (new_expression
+        ; exclude placement field
+        type: (_) @_start
+        arguments: (_) @_end)
+    (delete_expression (_) @_start @_end)
+] (#make-range! "range" @_start @_end))
+
+; the parenthesized parts of control flow statements
+([
+    ; if, while, switch
+    (condition_clause) @_start @_end
+
+    ; do-while
+    (do_statement condition: (_) @_start @_end)
+
+    ; for contents, initializer, condition and update
+    (for_statement . "(" @_start (_)* ")" @_end . (_))
+    (for_statement initializer: (_) @_start @_end . ";" @_end)
+    (for_statement condition: (_) @_start @_end . ";" @_end)
+    (for_statement update: (_) @_start @_end)
+
+    ; for range contents
+    (for_range_loop . "(" @_start (_)* ")" @_end . (_))
+] (#make-range! "range" @_start @_end))


### PR DESCRIPTION
An attempt at queries for C/C++. I tried to expand the notion of what the text subjects mean to also include lots of things specific to C/C++'s grammar:
- things that look like function calls: constructors, decltype, static_assert, sizeof
- definitions: lambdas, most top-level statements (e.g. using, typedefs, extern, etc.)
- other parameter-like lists: template argument/parameter lists, field initializer lists

with the idea that anything that looks vaguely like a container or looks like it should be a list gets included.