### PR TITLE
Remove deprecated if_let_expression from rust queries

### DIFF
--- a/queries/rust/textsubjects-smart.scm
+++ b/queries/rust/textsubjects-smart.scm
@@ -23,7 +23,6 @@
     (while_expression)
     (loop_expression)
     (if_expression)
-    (if_let_expression)
     (match_expression)
     (match_arm)
     (struct_item)


### PR DESCRIPTION
This expression type was removed in https://github.com/tree-sitter/tree-sitter-rust/commit/6ebdb1dc6cf4c19d8bae1d04f7bad44408e877d8