### PR TITLE
Remove jsx_fragment nodes from javascript and tsx queries

### DIFF
--- a/queries/javascript/textsubjects-smart.scm
+++ b/queries/javascript/textsubjects-smart.scm
@@ -21,7 +21,6 @@
     (switch_statement)
     ; jsx
     (jsx_element)
-    (jsx_fragment)
     (jsx_self_closing_element)
     (jsx_attribute)
 ] @_start @_end)

--- a/queries/tsx/textsubjects-big.scm
+++ b/queries/tsx/textsubjects-big.scm
@@ -5,7 +5,5 @@
     ; typescript
     (type_alias_declaration)
     (interface_declaration)
-    ; jsx
-    (jsx_fragment)
 ] @_start @_end)
 (#make-range! "range" @_start @_end))

--- a/queries/tsx/textsubjects-container-outer.scm
+++ b/queries/tsx/textsubjects-container-outer.scm
@@ -5,7 +5,5 @@
     ; typescript
     (type_alias_declaration)
     (interface_declaration)
-    ; jsx
-    (jsx_fragment)
 ] @_start @_end)
 (#make-range! "range" @_start @_end))

--- a/queries/tsx/textsubjects-smart.scm
+++ b/queries/tsx/textsubjects-smart.scm
@@ -24,7 +24,6 @@
     (interface_declaration)
     ; jsx
     (jsx_element)
-    (jsx_fragment)
     (jsx_self_closing_element)
     (jsx_attribute)
 ] @_start @_end)


### PR DESCRIPTION
[jsx_fragment nodes have been removed from the javascript grammar](https://github.com/tree-sitter/tree-sitter-javascript/commit/bb1f97b643b77fc1f082d621bf533b4b14cf0c30#diff-919ac210accac9ecc55a76d10a7590e3d85ca3f0e165b52d30f08faee486d0cbL592) (which is used by the tsx grammar).

[JSX fragments are now regular JSX opening and closing nodes](https://github.com/tree-sitter/tree-sitter-typescript/commit/b893426b82492e59388a326b824a346d829487e8#diff-7641e7dab915695b385ec7ba3ca3bf8c7bad9639df6795de4eb4703a98fecc16).

Using these jsx_fragment nodes in the queries caused treesitter to crash when parsing the queries. It prevented using this plugin with JavaScript and TSX files.

![image](https://github.com/RRethy/nvim-treesitter-textsubjects/assets/889383/126bc962-9d9c-41f4-bce1-702a0c9db816)

It no longer crashes when this PR is applied.