### PR TITLE
Update fennel queries for new parser included in nvim-treesitter

### DIFF
--- a/queries/fennel/textsubjects-container-inner.scm
+++ b/queries/fennel/textsubjects-container-inner.scm
@@ -1,38 +1,26 @@
-; ([(symbol) (number) (string) (binding)] @_start @_end
-;   (#make-range! "range" @_start @_end))
+;; Symbol
+((symbol) @_start @_end
+  (#make-range! "range" @_start @_end))
+
+;; Strings
+;; :abc
+;;  ^^^
+((string_content) @_start @_end
+ (#make-range! "range" @_start @_end))
 
 ;; Inner Seq
 ;; [...]
 ;;  ^^^
-((sequential_table . (_) @_start @_end (_)? @_end .)
+((sequence . (_) @_start @_end (_)? @_end .)
  (#make-range! "range" @_start @_end))
 
 ;; Inner Assoc
 ;; {...}
 ;;  ^^^
-((table . (_) @_start @_end (_)? @_end .)
- (#make-range! "range" @_start @_end))
+ ((table . (_) @_start @_end (_)? @_end .)
+  (#make-range! "range" @_start @_end))
 
-;; Inner List
-;; (...)
-;;  ^^^
-((_ . "(" . _ @_start @_end _* @_end . ")" .)
- (#make-range! "range" @_start @_end))
-
-;; (local {...} ...)
-;;         ^^^
-((table_binding . "{" . _ @_start @_end _? @_end . "}" .)
- (#make-range! "range" @_start @_end))
-
-;; (let [a 10 b 20] (...))
-;;       ^^^^^^^^^
-((let_clause . "[" . _ @_start @_end _+ @_end . "]" .)
- (#make-range! "range" @_start @_end))
-
-;; iterators
-;; It's probably not practical to assume how these should expand, so we will
-;; just expand out to the binds
-;; (icollect [a 10 b 20] (...))
-;;            ^^^^^^^^^
-((iter_bindings) @_start @_end
+;; (x ...)
+;;  ^^^^^
+((list . (_) @_start (_)* @_end)
  (#make-range! "range" @_start @_end))

--- a/queries/fennel/textsubjects-container-outer.scm
+++ b/queries/fennel/textsubjects-container-outer.scm
@@ -1,37 +1,19 @@
-;; Outer Seq
-;; [...]
-;; ^^^^^
-((sequential_table) @_start @_end
+;; :abc "abc"
+;; ^^^^ ^^^^^
+((string) @_start @_end
  (#make-range! "range" @_start @_end))
 
-;; Outer Assoc
+;; [...]
+;; ^^^^^
+((sequence) @_start @_end
+ (#make-range! "range" @_start @_end))
+
 ;; {...}
 ;; ^^^^^
 ((table) @_start @_end
  (#make-range! "range" @_start @_end))
 
-;; Outer List
-;; (...)
-;; ^^^^^
-((_ . "(" @_start . _+ . ")" @_end .)
- (#make-range! "range" @_start @_end))
-
-;; (local {...} ...)
-;;        ^^^^^
-((table_binding . "{" @_start "}" @_end .)
- (#make-range! "range" @_start @_end))
-
-;; (let [a 10 b 20] (...))
-;;      ^^^^^^^^^^^
-((let_clause . "[" @_start _? "]" @_end .)
- (#make-range! "range" @_start @_end))
-
-;; (icollect [a 10 b 20] (...))
-;;           ^^^^^^^^^^^
-;; cant use [(icollect) ...] here
-((icollect "[" @_start (iter_bindings) "]" @_end)
- (#make-range! "range" @_start @_end))
-((collect "[" @_start (iter_bindings) "]" @_end)
- (#make-range! "range" @_start @_end))
-((each "[" @_start (iter_bindings) "]" @_end)
+;; (x ...)
+;; ^^^^^^^
+((list) @_start @_end
  (#make-range! "range" @_start @_end))

--- a/queries/fennel/textsubjects-smart.scm
+++ b/queries/fennel/textsubjects-smart.scm
@@ -1,16 +1,27 @@
-; ([(symbol) (number) (string) (binding)] @_start @_end
-;   (#make-range! "range" @_start @_end))
+;; Symbol
+((symbol) @_start @_end
+  (#make-range! "range" @_start @_end))
+
+;; Strings
+;; :abc
+;;  ^^^
+((string_content) @_start @_end
+ (#make-range! "range" @_start @_end))
+;; :abc "abc"
+;; ^^^^ ^^^^^
+((string) @_start @_end
+ (#make-range! "range" @_start @_end))
 
 ;; Inner Seq
 ;; [...]
 ;;  ^^^
-((sequential_table . (_) @_start @_end (_)? @_end .)
+((sequence . (_) @_start @_end (_)? @_end .)
  (#make-range! "range" @_start @_end))
 
 ;; Outer Seq
 ;; [...]
 ;; ^^^^^
-((sequential_table) @_start @_end
+((sequence) @_start @_end
  (#make-range! "range" @_start @_end))
 
 ;; Assoc k-v pair
@@ -18,14 +29,14 @@
 ;;      ^^^^
 ;; {... : y ...}
 ;;      ^^^
-(table [":" (string)] @_start . (_) @_end
+((table_pair) @_start @_end
   (#make-range! "range" @_start @_end))
 
 ;; Inner Assoc
 ;; {...}
 ;;  ^^^
-((table . (_) @_start @_end (_)? @_end .)
- (#make-range! "range" @_start @_end))
+ ((table . (_) @_start @_end (_)? @_end .)
+  (#make-range! "range" @_start @_end))
 
 ;; Outer Assoc
 ;; {...}
@@ -33,91 +44,16 @@
 ((table) @_start @_end
  (#make-range! "range" @_start @_end))
 
-;; Strings
-;; :abc "abc"
-;; ^^^^ ^^^^^
-(((string) @_start @_end)
- (#make-range! "range" @_start @_end))
-
 ;; List arguments
 ;; (x ... ...)
 ;;    ^^^^^^^
-((_ . "(" . (_) . (_) @_start @_end (_)* @_end . ")" .)
+((list (symbol) . (_) @_start @_end (_)* @_end)
  (#make-range! "range" @_start @_end))
-
-;; Inner List
-;; (...)
-;;  ^^^
-((_ . "(" . _ @_start @_end _* @_end . ")" .)
+;; (x ...)
+;;  ^^^^^
+((list . (_) @_start (_)* @_end)
  (#make-range! "range" @_start @_end))
-
-;; Outer List
-;; (...)
-;; ^^^^^
-((_ . "(" @_start . _+ . ")" @_end .)
- (#make-range! "range" @_start @_end))
-
-;;; Specialised forms
-;;;
-;;; Specialised forms *look* like the above, but have different node names in
-;;; the tree sitter AST.
-
-;; Binding name-value pairs
-;; (local {... :x y ...} ...)
-;;             ^^^^
-;; (local {... : y ...} ...)
-;;             ^^^
-(table_binding [":" (string)] @_start . [(binding) (table_binding)] @_end
-  (#make-range! "range" @_start @_end))
-
-;; (local {...} ...)
-;;         ^^^
-((table_binding . "{" . _ @_start @_end _? @_end . "}" .)
- (#make-range! "range" @_start @_end))
-
-;; (local {...} ...)
-;;        ^^^^^
-((table_binding . "{" @_start "}" @_end .)
- (#make-range! "range" @_start @_end))
-
-;;; let_clause
-;;; First expand to the nearest binding pair, then all the bindings (inner) then
-;;; all the bindings (outer)
-;;; So 10 -> `x 10`, x -> `x 10` then `x 10 y 20` then `[x 10 y 20]`
-;; (let [a 10 b 20] (...))
-;;       ^^^^
-;; (or `b 20`)
-((let_clause [(binding)
-              (table_binding)
-              (multi_value_binding)
-              (sequential_table_binding)] @_start
-             . (_) @_end)
- (#make-range! "range" @_start @_end))
-
-;; (let [a 10 b 20] (...))
-;;       ^^^^^^^^^
-((let_clause . "[" . _ @_start @_end _+ @_end . "]" .)
- (#make-range! "range" @_start @_end))
-
-;; (let [a 10 b 20] (...))
-;;      ^^^^^^^^^^^
-((let_clause . "[" @_start _? "]" @_end .)
- (#make-range! "range" @_start @_end))
-
-;; iterators
-;; It's probably not practical to assume how these should expand, so we will
-;; just expand out to the binds
-;; (icollect [a 10 b 20] (...))
-;;            ^^^^^^^^^
-((iter_bindings) @_start @_end
- (#make-range! "range" @_start @_end))
-
-;; (icollect [a 10 b 20] (...))
-;;           ^^^^^^^^^^^
-;; cant use [(icollect) ...] here
-((icollect "[" @_start (iter_bindings) "]" @_end)
- (#make-range! "range" @_start @_end))
-((collect "[" @_start (iter_bindings) "]" @_end)
- (#make-range! "range" @_start @_end))
-((each "[" @_start (iter_bindings) "]" @_end)
+;; (x ...)
+;; ^^^^^^^
+((list) @_start @_end
  (#make-range! "range" @_start @_end))


### PR DESCRIPTION
The new fennel parser included with nvim-treesitter uses different capture groups. Most behaviour is broadly the same but the new parser seems to select more white space than the previous parser.