### PR TITLE
Fix injections that use #!set injection.language

### DIFF
--- a/lua/nvim-treesitter-textsubjects.lua
+++ b/lua/nvim-treesitter-textsubjects.lua
@@ -30,6 +30,15 @@ function M.init()
                                 return true
                             end
                         end
+
+                        for _, info in ipairs(query.info.patterns) do
+                            -- we're looking for #set injection.language <whatever>
+                            if info[1][1] == "set!" and info[1][2] == "injection.language" then
+                                if has_nested_textsubjects_language(info[1][3]) then
+                                    return true
+                                end
+                            end
+                        end
                     end
 
                     return false


### PR DESCRIPTION
I was trying to use the `html` text-subjects in an `htmldjango` file - and I noticed that it wasn't picking up the `html` injections from this plugin.

It looks like the guidance for how to set injections may have changed since the code to support text-subjects in injected languages was merged?  The "blessed" way - according to the documentation is like this:

```
((content) @injection.content
 (#set! injection.language "html")
 (#set! injection.combined))
```

This is the way that the `htmldjango` tree-sitter queries do it as well - effectively injecting `html` into the `htmldjango` language.

I changed this bit of the plugin when we're detecting whether the language can use the text-subjects of an injection and my custom text-subjects for `htmldjango` as well as the injected `html` subjects are now working.