### PR TITLE
refactor: remove dependency on nvim-treesitter

### DIFF
--- a/lua/nvim-treesitter-textsubjects.lua
+++ b/lua/nvim-treesitter-textsubjects.lua
@@ -105,41 +105,28 @@ local function make_range_handler(match, _, source, predicate, metadata)
 end
 
 function M.init()
-    if vim.fn.has('nvim-0.9') == 1 then
-        vim.treesitter.query.add_directive("make-range!", make_range_handler, {
-            force = true,
-            all = true,
-        })
+    vim.treesitter.query.add_directive("make-range!", make_range_handler, {
+        force = true,
+        all = true,
+    })
 
-        vim.api.nvim_create_autocmd({ 'FileType' }, {
-            callback = function(details)
-                require('nvim-treesitter.textsubjects').detach(details.buf)
+    vim.api.nvim_create_autocmd({ 'FileType' }, {
+        callback = function(details)
+            require('nvim-treesitter.textsubjects').detach(details.buf)
 
-                local lang = vim.treesitter.language.get_lang(details.match)
-                if not M.is_supported(lang) then
-                    return
-                end
+            local lang = vim.treesitter.language.get_lang(details.match)
+            if not M.is_supported(lang) then
+                return
+            end
 
-                require('nvim-treesitter.textsubjects').attach(details.buf)
-            end,
-        })
-        vim.api.nvim_create_autocmd({ 'BufUnload' }, {
-            callback = function(details)
-                require('nvim-treesitter.textsubjects').detach(details.buf)
-            end,
-        })
-    else
-        require "nvim-treesitter".define_modules {
-            textsubjects = {
-                module_path = "nvim-treesitter.textsubjects",
-                enable = false,
-                disable = {},
-                prev_selection = nil,
-                keymaps = {},
-                is_supported = M.is_supported,
-            }
-        }
-    end
+            require('nvim-treesitter.textsubjects').attach(details.buf)
+        end,
+    })
+    vim.api.nvim_create_autocmd({ 'BufUnload' }, {
+        callback = function(details)
+            require('nvim-treesitter.textsubjects').detach(details.buf)
+        end,
+    })
 end
 
 return M

--- a/lua/nvim-treesitter-textsubjects.lua
+++ b/lua/nvim-treesitter-textsubjects.lua
@@ -50,8 +50,67 @@ function M.is_supported(lang)
     return has_nested_textsubjects_language(lang)
 end
 
+---@param match table<integer, TSNode[]>
+---@param source integer|string
+---@param predicate any[]
+---@param metadata vim.treesitter.query.TSMetadata
+local function make_range_handler(match, _, source, predicate, metadata)
+    if #predicate ~= 4 then
+        print("make-range directive requires exactly three arguments, got" .. #predicate - 1)
+        return
+    end
+
+    local name, start, end_ = predicate[2], predicate[3], predicate[4]
+    if type(name) ~= "string" then
+        print("make-range directive first argument must be a string, defining the range's name")
+        return
+    end
+
+    if type(start) ~= "number" or type(end_) ~= "number" then
+        print("make-range directive second and third arguments must be captures, defining the range's start and end")
+        return
+    end
+
+    -- LuaLS does not understand the type() above guarantees these are numbers
+    ---@type number, number
+    local start_capture, end_capture = start, end_
+
+    ---@type number?, number?, number?
+    local start_row, start_col, start_bytes = nil, nil, nil
+    for _, node in ipairs(match[start]) do
+        local range = vim.treesitter.get_range(node, source, metadata[start_capture])
+        local row, col, bytes = range[1], range[2], range[3]
+        if not start_row or row < start_row or (row == start_row and col < start_col) then
+            start_row, start_col, start_bytes = row, col, bytes
+        end
+    end
+
+
+    ---@type number?, number?, number?
+    local end_row, end_col, end_bytes = nil, nil, nil
+    for _, node in ipairs(match[end_capture]) do
+        local range = vim.treesitter.get_range(node, source, metadata[end_capture])
+        local row, col, bytes = range[4], range[5], range[6]
+        if not end_row or row > end_row or (row == end_row and col > end_col) then
+            end_row, end_col, end_bytes = row, col, bytes
+        end
+    end
+
+    metadata.ranges = metadata.ranges or {}
+    metadata.ranges[name] = metadata.ranges[name] or {}
+    table.insert(metadata.ranges[name], {
+        start_row, start_col, start_bytes,
+        end_row, end_col, end_bytes,
+    })
+end
+
 function M.init()
     if vim.fn.has('nvim-0.9') == 1 then
+        vim.treesitter.query.add_directive("make-range!", make_range_handler, {
+            force = true,
+            all = true,
+        })
+
         vim.api.nvim_create_autocmd({ 'FileType' }, {
             callback = function(details)
                 require('nvim-treesitter.textsubjects').detach(details.buf)

--- a/lua/nvim-treesitter-textsubjects.lua
+++ b/lua/nvim-treesitter-textsubjects.lua
@@ -1,6 +1,3 @@
-local queries = require("nvim-treesitter.query")
-local parsers = require('nvim-treesitter.parsers')
-
 local M = {}
 
 function M.configure(config_overrides)
@@ -14,13 +11,14 @@ function M.is_supported(lang)
             return false
         end
 
-        if not parsers.has_parser(nested_lang) then
+        -- Officially documented way to check for parser availability
+        if not vim.treesitter.language.add(nested_lang) then
             return false
         end
 
-        if queries.has_query_files(nested_lang, 'textsubjects-smart')
-            or queries.has_query_files(nested_lang, 'textsubjects-container-outer')
-            or queries.has_query_files(nested_lang, 'textsubjects-container-inner') then
+        if vim.treesitter.query.get(nested_lang, 'textsubjects-smart')
+            or vim.treesitter.query.get(nested_lang, 'textsubjects-container-outer')
+            or vim.treesitter.query.get(nested_lang, 'textsubjects-container-inner') then
             return true
         end
         if seen[nested_lang] then
@@ -28,8 +26,8 @@ function M.is_supported(lang)
         end
         seen[nested_lang] = true
 
-        if queries.has_query_files(nested_lang, 'injections') then
-            local query = queries.get_query(nested_lang, 'injections')
+        local query = vim.treesitter.query.get(nested_lang, 'injections')
+        if query then
             for _, capture in ipairs(query.info.captures) do
                 if capture == 'language' or has_nested_textsubjects_language(capture) then
                     return true

--- a/lua/nvim-treesitter/textsubjects.lua
+++ b/lua/nvim-treesitter/textsubjects.lua
@@ -1,6 +1,3 @@
-local parsers = require('nvim-treesitter.parsers')
-local queries = require('nvim-treesitter.query')
-local ts_utils = require('nvim-treesitter.ts_utils')
 local config = require('textsubjects.config')
 
 local M = {}
@@ -101,19 +98,98 @@ local function normalize_selection(sel_start, sel_end)
     return { sel_start_row, sel_start_col, sel_end_row, sel_end_col }
 end
 
+local function get_buf_lang(bufnr)
+    return vim.treesitter.language.get_lang(vim.bo[bufnr].filetype)
+end
+
+---Encapsulate the range represented by a capture match
+---@class MatchRange
+---@field start_row integer
+---@field start_col integer
+---@field end_row integer
+---@field end_col integer
+
+
+---Get all ranges defined by the given query for the given root node
+---@param bufnr integer
+---@param query_name string Query to extract ranges from
+---@param lang string Language of the
+---@param root TSNode Root node to query
+---@return Range4[]
+local function get_query_ranges(bufnr, query_name, lang, root)
+    local query = vim.treesitter.query.get(lang, query_name)
+    if not query then return {} end
+
+    local ranges = {}
+
+    for _, _, metadata, _ in query:iter_matches(root, bufnr) do
+        local all_ranges = metadata.ranges --[[@as table<string, Range6[]>]]
+        local our_ranges = all_ranges and all_ranges["range"]
+        local range = our_ranges and our_ranges[1]
+
+        if range then
+            table.insert(ranges, { range[1], range[2], range[4], range[5] })
+        end
+    end
+
+    return ranges
+end
+
+---Get matches for all languages in the buffer recursively
+---@param bufnr integer Buffer whose contents to query
+---@param query_name string Query to extract captures from
+---@return Range4[]
+local function get_query_ranges_recursively(bufnr, query_name)
+    local parser = vim.treesitter.get_parser(bufnr)
+    if not parser then return {} end
+
+    local matches = {}
+
+    parser:for_each_tree(function(tree, lang_tree)
+        local lang = lang_tree:lang()
+        local root = tree:root()
+
+        vim.list_extend(matches, get_query_ranges(bufnr, query_name, lang, root))
+    end)
+
+    return matches
+end
+
+---@param bufnr integer
+---@param range Range4
+---@param sel_mode? "v" | "V"
+local function update_selection(bufnr, range, sel_mode)
+    local start_row, start_col, end_row, end_col = unpack(range)
+    local selection_mode = sel_mode or 'v'
+
+    if vim.api.nvim_get_mode().mode ~= sel_mode then
+        vim.cmd.normal({ sel_mode, bang = true })
+    end
+
+    if end_col == 0 then
+        -- If end_col is 0, we need to go past the end of the previous line
+        end_row = end_row - 1
+        end_col = #vim.api.nvim_buf_get_lines(bufnr, end_row, end_row + 1, true)[1] + 1
+    end
+
+    local exclusive_offset = selection_mode == 'v' and vim.o.selection == 'exclusive' and 1 or 0
+    end_col = end_col - exclusive_offset
+
+    -- Row indices are 1-based for nvim_win_set_cursor
+    vim.api.nvim_win_set_cursor(0, { start_row + 1, start_col })
+    vim.cmd.normal({ 'o', bang = true })
+    vim.api.nvim_win_set_cursor(0, { end_row + 1, end_col })
+end
+
 function M.select(query, restore_visual, sel_start, sel_end)
     local bufnr = vim.api.nvim_get_current_buf()
-    local lang = parsers.get_buf_lang(bufnr)
+    local lang = get_buf_lang(bufnr)
     if not lang then return end
 
     local sel = normalize_selection(sel_start, sel_end)
     local best
-    local matches = queries.get_capture_matches_recursively(bufnr, '@range', query)
-    for _, m in pairs(matches) do
-        local match_start_row, match_start_col = unpack(m.node.start_pos)
-        local match_end_row, match_end_col = unpack(m.node.end_pos)
-        local match = { match_start_row, match_start_col, match_end_row, match_end_col }
-
+    local matches = get_query_ranges_recursively(bufnr, query)
+    for _, match in pairs(matches) do
         -- match must cover an exclusively bigger range than the current selection
         if does_surround(match, sel) then
             if not best or does_surround(best, match) then
@@ -124,7 +200,7 @@ function M.select(query, restore_visual, sel_start, sel_end)
 
     if best then
         local new_best, sel_mode = extend_range_with_whitespace(best)
-        ts_utils.update_selection(bufnr, new_best, sel_mode)
+        update_selection(bufnr, new_best, sel_mode)
         local selections = prev_selections[bufnr]
         if selections == nil or not does_surround(new_best, selections[#selections][1]) then
             prev_selections[bufnr] = {
@@ -186,7 +262,7 @@ function M.prev_select(sel_start, sel_end)
     end
 
     local new_sel, sel_mode = unpack(selections[#selections])
-    ts_utils.update_selection(bufnr, new_sel, sel_mode)
+    update_selection(bufnr, new_sel, sel_mode)
     vim.cmd('normal! o')
 end
 

--- a/lua/textsubjects/config.lua
+++ b/lua/textsubjects/config.lua
@@ -14,16 +14,6 @@ function M.set(config_overrides)
 end
 
 function M.get()
-    local ok, configs = pcall(require, 'nvim-treesitter.configs')
-    if not ok then
-        return config
-    end
-
-    local ts_config = configs.get_module('textsubjects')
-    if ts_config then
-        return ts_config
-    end
-
     return config
 end
 


### PR DESCRIPTION
I know #53 already exists and much of what I did likely overlaps with that, but I have taken a slightly different approach in some aspects.

Mainly, I rewrote `#make-range!` to be an actual directive, rather than the pseudo-directive it used to be under the old nvim-treesitter. In my opinion, this makes the code that's processing the actual matches a lot cleaner, since it doesn't have to do all the directive processing as well.

Furthermore, I opted to refactor certain code segments, mainly in the match processing code, so that reimplemented functionality could be trimmed down to match the needs of this plugin.